### PR TITLE
Pipeline able to read and save images

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -1,6 +1,6 @@
 #include "pipeline.hpp"
 
-Pipeline::Pipeline(){
+Pipeline::Pipeline() {
     this->pipelineMutex = new std::mutex();
     this->running = true;
     this->logger = new ThreadLogger();
@@ -8,53 +8,69 @@ Pipeline::Pipeline(){
     this->stateManager = new StateManager(logger);
     this->stateManager->transitionTo(new IdlingState());
     this->ioBridge = new IOBridge(logger, stateManager);
-    stateManager -> pushShutdown([this](){this -> stop();});
+    stateManager->pushShutdown([this]() { this->stop(); });
 }
 
-Pipeline::~Pipeline(){
+Pipeline::~Pipeline() {
     delete this->stateManager;
     delete this->ioBridge;
     delete this->logger;
     delete this->pipelineMutex;
 }
 
-bool Pipeline::isRunning(){
+bool Pipeline::isRunning() {
     std::lock_guard<std::mutex> lock(*this->pipelineMutex);
     return this->running;
 }
 
-void Pipeline::stop(){
-    this -> logger -> log("Stopping system pipeline...");
+void Pipeline::stop() {
+    this->logger->log("Stopping system pipeline...");
     std::lock_guard<std::mutex> lock(*this->pipelineMutex);
     this->running = false;
 }
 
-int Pipeline::initDrive(){
+int Pipeline::initDrive() {
     std::string mountPoint = "/media/usbdrive";
     // Unmount the USB drive
-    std::string unmountCmd = "sudo umount " +  mountPoint;
+    std::string unmountCmd = "sudo umount " + mountPoint;
     int unmountResult = system(unmountCmd.c_str());
 
     if (unmountResult == 0) {
-        Pipeline::logger->log("USB drive unmounted successfully from %s",  mountPoint.c_str());
+        logger->log("USB drive unmounted successfully from %s", mountPoint.c_str());
     } else {
-        Pipeline::logger->log("Failed to unmount USB drive.");
+        logger->log("Failed to unmount USB drive.");
     }
 
     return unmountResult;
 }
 
-
-void Pipeline::run(){
+void Pipeline::run() {
     initDrive();
     while (this->isRunning()) {
-        this->stateManager -> runStateProcess();
-        IState * reqState = this->stateManager -> getRequestedState();
+        this->stateManager->runStateProcess();
+        IState* reqState = this->stateManager->getRequestedState();
         if (reqState != nullptr) {
-            this->stateManager -> transitionTo(reqState);
-            this->stateManager -> requestState(nullptr);
-            this->stateManager -> setTransitionState(true);
+            this->stateManager->transitionTo(reqState);
+            this->stateManager->requestState(nullptr);
+            this->stateManager->setTransitionState(true);
         }
     }
 }
 
+cv::Mat Pipeline::readImage(const std::string &imagePath) {
+    cv::Mat image = cv::imread(imagePath, cv::IMREAD_COLOR);
+    if (image.empty()) {
+        logger->log("Error: Image file could not be read.");
+        return cv::Mat();
+    }
+    logger->log("Image read successfully.");
+    return image;
+}
+
+void Pipeline::saveImage(const std::string &outputPath, const cv::Mat &image) {
+    if (cv::imwrite(outputPath, image)) {
+        logger->log("Image saved successfully to %s", outputPath.c_str());
+    } else {
+        logger->log("Error: Failed to save the image.");
+    }
+}

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -3,29 +3,33 @@
 #include "state/ProcessingState.hpp"
 #include "utils/ThreadLogger.hpp"
 #include "bridge/IOBridge.hpp"
+#include <opencv2/opencv.hpp>
 #include <filesystem>
 #include <string>
 #include <mutex>
 
-
 #ifndef PIPELINE_HPP
 #define PIPELINE_HPP
 
-class Pipeline{
-    public:
-        Pipeline();
-        virtual ~Pipeline();
-        virtual void run();
-    protected:
-        virtual bool isRunning();
-        virtual void stop();
-	virtual int initDrive();
-    private:
-        bool running;
-        std::mutex * pipelineMutex;
-        ThreadLogger * logger;
-        StateManager * stateManager;
-        IOBridge * ioBridge;
+class Pipeline {
+public:
+    Pipeline();
+    virtual ~Pipeline();
+    virtual void run();
+    cv::Mat readImage(const std::string &imagePath); // Added method to read an image
+    void saveImage(const std::string &outputPath, const cv::Mat &image);
+
+protected:
+    virtual bool isRunning();
+    virtual void stop();
+    virtual int initDrive();
+
+private:
+    bool running;
+    std::mutex * pipelineMutex;
+    ThreadLogger * logger;
+    StateManager * stateManager;
+    IOBridge * ioBridge;
 };
 
 #endif //PIPELINE_HPP


### PR DESCRIPTION
- Allows an image to be read into the pipeline from payload interface.
- Allows a resulting image to be saved after the pipeline finished processing.